### PR TITLE
Upgrade marked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@coseeing/access8math-web-lib",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coseeing/access8math-web-lib",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
-        "marked": "^5.1.0",
+        "marked": "^14.1.2",
         "mathjax-full": "^3.2.2"
       },
       "devDependencies": {
@@ -15697,14 +15697,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
-      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.2.tgz",
+      "integrity": "sha512-f3r0yqpz31VXiDB/wj9GaOB0a2PRLQl6vJmXiFrniNwjkKdvakqJRULhjFKJpxOchlCRiG5fcacoUZY5Xa6PEQ==",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18"
       }
     },
     "node_modules/mathjax-full": {
@@ -33962,9 +33962,9 @@
       }
     },
     "marked": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
-      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg=="
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.2.tgz",
+      "integrity": "sha512-f3r0yqpz31VXiDB/wj9GaOB0a2PRLQl6vJmXiFrniNwjkKdvakqJRULhjFKJpxOchlCRiG5fcacoUZY5Xa6PEQ=="
     },
     "mathjax-full": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "homepage": "./",
   "dependencies": {
-    "marked": "^5.1.0",
+    "marked": "^14.1.2",
     "mathjax-full": "^3.2.2"
   },
   "scripts": {

--- a/src/lib/shared/content-processor/markdown-process.js
+++ b/src/lib/shared/content-processor/markdown-process.js
@@ -105,8 +105,11 @@ const markedProcessorFactory = ({
     },
   };
   const renderer = {
-    text(text) {
-      return text.replace(/\n/g, '<br />');
+    text(token) {
+      if (token.tokens?.length > 0) {
+        return this.parser.parseInline(token.tokens);
+      }
+      return token.text.replace(/\n/g, '<br />');
     },
   };
 
@@ -115,8 +118,6 @@ const markedProcessorFactory = ({
   marked.use({
     extensions: [math],
     renderer,
-    mangle: false,
-    headerIds: false,
   });
 
   return (raw) => {


### PR DESCRIPTION
## Description
因為想要使用 [marked-alert](https://github.com/bent10/marked-extensions/tree/main/packages/alert) extension 但發現版本 marked 太舊了無法安裝，所以想先升級 marked。

列出一些有影響的 breaking change
- [v8.0](https://github.com/markedjs/marked/releases/tag/v8.0.0) 時有移除一些 options
- [v13.0](https://github.com/markedjs/marked/releases/tag/v13.0.0) 有調整 renderer 的參數