### PR TITLE
Fix internal link navigation behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coseeing/access8math-web-lib",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "./",
   "dependencies": {
     "marked": "^14.1.2",

--- a/src/lib/link.js
+++ b/src/lib/link.js
@@ -126,6 +126,10 @@ class YoutubeVideo {
   }
 }
 
+function isInternalLink(path) {
+  return path.startsWith('#');
+}
+
 function linkHandler(htmlStr) {
   const temp = document.createElement('div');
   temp.innerHTML = htmlStr;
@@ -134,6 +138,10 @@ function linkHandler(htmlStr) {
     let assetPath = element.getAttribute('href');
     if (!assetPath) {
       element.setAttribute('target', `blank`);
+      return;
+    }
+
+    if (isInternalLink(assetPath)) {
       return;
     }
 

--- a/src/lib/shared/content-processor/extensions/internalLink.js
+++ b/src/lib/shared/content-processor/extensions/internalLink.js
@@ -73,7 +73,7 @@ function markedInternalLink() {
           }
         },
         renderer(token) {
-          return `<a href="/#${token.id}" id="${token.id}-source" class="underline ${LINK_COLOR}">${token.text}</a>`;
+          return `<a href="#${token.id}" id="${token.id}-source" class="underline ${LINK_COLOR}">${token.text}</a>`;
         }
       },
       {
@@ -88,7 +88,7 @@ function markedInternalLink() {
               class="px-4 mb-4 border-l-4 ${QUOTE_BORDER_COLOR}"
             >
               ${this.parser.parse(tokens)}
-              <a href="/#${meta.id}-source" class="underline ${LINK_COLOR}">返回</a>
+              <a href="#${meta.id}-source" class="underline ${LINK_COLOR}">返回</a>
             </div>
           `;
         }


### PR DESCRIPTION
## Description
1. When exporting to HTML, directly opening the index.html file and clicking an internal link would navigate to the file directory. This happens because the href for internal links is incorrectly set, which breaks the expected navigation behavior.
2. Fixed an error in link.js that occurred when processing internal links. This change ensures that internal links work as expected and prevents unnecessary attributes from being added.
