### PR TITLE
Fix error when using `` inside alert or internal link syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coseeing/access8math-web-lib",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "homepage": "./",
   "dependencies": {
     "marked": "^14.1.2",

--- a/src/lib/shared/content-processor/extensions/alert.js
+++ b/src/lib/shared/content-processor/extensions/alert.js
@@ -65,11 +65,7 @@ function createCleanedPatternToken(token, regexp) {
     ...token,
     raw: token.raw.replace(regexp, ''),
     text: token.text.replace(regexp, ''),
-    tokens: token.tokens?.map?.(token => ({
-      ...token,
-      raw: token.raw.replace(regexp, ''),
-      text: token.text.replace(regexp, ''),
-    })),
+    tokens: token.tokens?.map?.(token => createCleanedPatternToken(token, regexp)),
   };
 }
 

--- a/src/lib/shared/content-processor/extensions/alert.js
+++ b/src/lib/shared/content-processor/extensions/alert.js
@@ -64,7 +64,12 @@ function createCleanedPatternToken(token, regexp) {
   return {
     ...token,
     raw: token.raw.replace(regexp, ''),
-    text: token.text.replace(regexp, '')
+    text: token.text.replace(regexp, ''),
+    tokens: token.tokens?.map?.(token => ({
+      ...token,
+      raw: token.raw.replace(regexp, ''),
+      text: token.text.replace(regexp, ''),
+    })),
   };
 }
 
@@ -80,7 +85,7 @@ function createProcessedFirstLine(firstLine, typeRegexp) {
     tokens: [
       createCleanedPatternToken(patternToken, typeRegexp),
       ...createValidFirstTokens(firstToken),
-      ...remainingTokens
+      ...remainingTokens,
     ]
   };
 }

--- a/src/lib/shared/content-processor/extensions/internalLink.js
+++ b/src/lib/shared/content-processor/extensions/internalLink.js
@@ -8,12 +8,12 @@ function createValidFirstTokens(token) {
   return token && token.type !== 'br' ? [token] : [];
 }
 
-function cleanTokens(token) {
+function createCleanedPatternToken(token) {
   return {
     ...token,
     raw: token.raw.replace(QUOTE_REGEXP, ''),
     text: token.text.replace(QUOTE_REGEXP, ''),
-    tokens: token.tokens?.map?.(token => cleanTokens(token)),
+    tokens: token.tokens?.map?.(token => createCleanedPatternToken(token)),
   };
 }
 
@@ -23,7 +23,7 @@ function createProcessedFirstLine(firstLine) {
   return {
     ...firstLine,
     tokens: [
-      cleanTokens(patternToken),
+      createCleanedPatternToken(patternToken),
       ...createValidFirstTokens(firstToken),
       ...remainingTokens
     ]

--- a/src/lib/shared/content-processor/extensions/internalLink.js
+++ b/src/lib/shared/content-processor/extensions/internalLink.js
@@ -8,22 +8,22 @@ function createValidFirstTokens(token) {
   return token && token.type !== 'br' ? [token] : [];
 }
 
+function cleanTokens(token) {
+  return {
+    ...token,
+    raw: token.raw.replace(QUOTE_REGEXP, ''),
+    text: token.text.replace(QUOTE_REGEXP, ''),
+    tokens: token.tokens?.map?.(token => cleanTokens(token)),
+  };
+}
+
 function createProcessedFirstLine(firstLine) {
   const [patternToken, firstToken, ...remainingTokens] = firstLine.tokens;
   
   return {
     ...firstLine,
     tokens: [
-      {
-        ...patternToken,
-        raw: patternToken.raw.replace(QUOTE_REGEXP, ''),
-        text: patternToken.text.replace(QUOTE_REGEXP, ''),
-        tokens: patternToken.tokens?.map?.(token => ({
-          ...token,
-          raw: token.raw.replace(QUOTE_REGEXP, ''),
-          text: token.text.replace(QUOTE_REGEXP, ''),
-        })),
-      },
+      cleanTokens(patternToken),
       ...createValidFirstTokens(firstToken),
       ...remainingTokens
     ]

--- a/src/lib/shared/content-processor/extensions/internalLink.js
+++ b/src/lib/shared/content-processor/extensions/internalLink.js
@@ -17,7 +17,12 @@ function createProcessedFirstLine(firstLine) {
       {
         ...patternToken,
         raw: patternToken.raw.replace(QUOTE_REGEXP, ''),
-        text: patternToken.text.replace(QUOTE_REGEXP, '')
+        text: patternToken.text.replace(QUOTE_REGEXP, ''),
+        tokens: patternToken.tokens?.map?.(token => ({
+          ...token,
+          raw: token.raw.replace(QUOTE_REGEXP, ''),
+          text: token.text.replace(QUOTE_REGEXP, ''),
+        })),
       },
       ...createValidFirstTokens(firstToken),
       ...remainingTokens

--- a/src/lib/shared/content-processor/markdown-process.js
+++ b/src/lib/shared/content-processor/markdown-process.js
@@ -86,7 +86,8 @@ const markedProcessorFactory = ({
           type: 'math',
           typed,
           raw: match[0],
-          text: this.lexer.inlineTokens(match[1]),
+          text: match[1] || '',
+          tokens: this.lexer.inlineTokens(match[1]),
           math: math ? math.trim() : '',
           mathraw: match[2],
         };
@@ -100,7 +101,7 @@ const markedProcessorFactory = ({
         mathMl = latex2mml(token.math);
       }
       return `${this.parser.parseInline(
-        token.text,
+       token.tokens,
       )}<span class="sr-only">${mathMl}</span><span aria-hidden="true">${mml2svg(
         mathMl,
       )}</span>`;

--- a/src/lib/shared/content-processor/markdown-process.js
+++ b/src/lib/shared/content-processor/markdown-process.js
@@ -101,7 +101,7 @@ const markedProcessorFactory = ({
         mathMl = latex2mml(token.math);
       }
       return `${this.parser.parseInline(
-       token.tokens,
+        token.tokens,
       )}<span class="sr-only">${mathMl}</span><span aria-hidden="true">${mml2svg(
         mathMl,
       )}</span>`;


### PR DESCRIPTION
### Description
This PR resolves a bug in the editor, where an incompatibility between math and alert extensions causes errors during the rendering process.

### Steps to reproduce the issue:
```md
> [!NOTE]
> hello
> ``
```

### Problem
- In the current implementation, math extensions return an array for text during tokenize, but alert and internal link extensions assume it to be a string.
- This causes runtime errors when alert and internal link extensions attempt to apply string methods to the text.

### Solution
1. math extensions:
  - Introduced a tokens field to better structure the data needed for rendering.
2. alert & internal link extensions
  - Update the handling of 'tokens' in createCleanedPatternToken to utilize recursion for cleaning 'raw' and 'text' properties.

### Workflow Explanation
In the marked processing pipeline, the following steps occur:
1. math extension’s tokenize: This processes the input text and creates a token structure, now including the new tokens field for nested data.
2. alert(internal link) extension’s walkTokens: This step traverses all tokens, including the nested tokens provided by the math extension, ensuring proper handling and processing.
4. alert(internal link) extension’s render: Uses the processed tokens from walkTokens to generate the appropriate output, accommodating the nested tokens.
5. math extension’s render: Handles the final rendering based on the updated token structure.